### PR TITLE
Restore libtool but with disable-shared option.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,13 +5,14 @@ ACLOCAL_AMFLAGS = -I build/autotools/m4
 # Options passed to the C PreProcessor (CPP), NOT the C Plus Plus compiler.
 AM_CPPFLAGS = -I${top_srcdir}/ $(DEPS_CFLAGS)
 
-lib_LIBRARIES = libmemtailor.a
+# tell Libtool what the name of the library is.
+lib_LTLIBRARIES = libmemtailor.la
 
 # set the C++ compiler to include src/
 AM_CXXFLAGS=-I$(top_srcdir)/src/ -std=gnu++0x
 
 # the sources that are built to make the library
-libmemtailor_a_SOURCES =		\
+libmemtailor_la_SOURCES =		\
   src/memtailor/BufferPool.cpp src/memtailor/Arena.cpp	\
   src/memtailor/MemoryBlocks.cpp src/memtailor.cpp
 
@@ -40,7 +41,7 @@ TESTS=unittest
 check_PROGRAMS=$(TESTS)
 
 unittest_CXXFLAGS = -I$(top_srcdir)/src/ -std=gnu++0x
-unittest_LDADD = $(top_builddir)/libmemtailor.a -lpthread
+unittest_LDADD = $(top_builddir)/libmemtailor.la -lpthread
 
 # test_LIBS=
 unittest_SOURCES=src/test/ArenaTest.cpp src/test/BufferPoolTest.cpp	\

--- a/configure.ac
+++ b/configure.ac
@@ -111,7 +111,8 @@ AC_PROG_INSTALL
 # Locate the C++ compiler.
 AC_PROG_CXX
 
-AC_PROG_RANLIB
+# Set up LibTool
+LT_INIT([disable-shared])
 
 dnl Set the version for the library -- this concerns compatibility of the
 dnl source and binary interface of the library and is not the same as the


### PR DESCRIPTION
This reverts commit d87680a, but the addition of the disable-shared option
still prevents the building of shared libraries by default.

If shared libraries are desired (e.g., for the Debian package), users may
run ./configure --enable-shared.
