### PR TITLE
Use test -e instead of AC_CHECK_FILE for cross building.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,7 +32,7 @@ AS_IF([test "x$GTEST_VERSION" == "x"], [GTEST_VERSION="1.6.0"])
 AS_IF([test "x$with_gtest" == "x"], [with_gtest="download"])
 
 AS_IF([test "x$with_gtest" == "xdownload"],
-  [with_gtest="yes"; AC_CHECK_FILE([$GTEST_PATH/src/gtest-all.cc], [], [
+  [with_gtest="yes"; AS_IF([test -e "$GTEST_PATH/src/gtest-all.cc"], [], [
     echo "downloading of gtest disabled" >&2; exit 1
     mkdir -p "$GTEST_PATH";
     (
@@ -52,7 +52,7 @@ AS_IF([test "x$with_gtest" == "xdownload"],
     fi
   ])],
   [test "x$with_gtest" == "xyes"], [
-    AC_CHECK_FILE([$GTEST_PATH/src/gtest-all.cc], [], [
+    AS_IF([test -e "$GTEST_PATH/src/gtest-all.cc"], [], [
       AC_MSG_ERROR([could not find gtest source at path $GTEST_PATH.])
     ])
   ],


### PR DESCRIPTION
Patch by Helmut Grohne <helmut@subdivi.de> for Debian bug #941402 [1].

> memtailor fails to cross build from source, because it abuses
> AC_CHECK_FILE. The macro is meant to check for files on the host system,
> but memtailor uses it to check for files expected on the build system.
> Please use a simple test -e for the latter. Please consider applying the
> attached patch.

[1] https://bugs.debian.org/941402