### PR TITLE
Link against gtest instead of building it

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,7 @@
 ACLOCAL_AMFLAGS = -I build/autotools/m4
 
 # Options passed to the C PreProcessor (CPP), NOT the C Plus Plus compiler.
-AM_CPPFLAGS = -I${top_srcdir}/ $(DEPS_CFLAGS)
+AM_CPPFLAGS = -I${top_srcdir}/
 
 # tell Libtool what the name of the library is.
 lib_LTLIBRARIES = libmemtailor.la
@@ -41,17 +41,16 @@ TESTS=unittest
 check_PROGRAMS=$(TESTS)
 
 unittest_CXXFLAGS = -I$(top_srcdir)/src/ -std=gnu++17
-unittest_LDADD = $(top_builddir)/libmemtailor.la -lpthread
+unittest_LDADD = $(top_builddir)/libmemtailor.la -lpthread -lgtest
 
 # test_LIBS=
 unittest_SOURCES=src/test/ArenaTest.cpp src/test/BufferPoolTest.cpp	\
-  src/test/MemoryBlocksTest.cpp src/test/testMain.cpp				\
-  src/test/gtestInclude.cpp
+  src/test/MemoryBlocksTest.cpp src/test/testMain.cpp
 
 else
 
 check:
 	@echo
-	@echo "Configure did not locate gtest, so unittests cannot be run."
+	@echo "configured without gtest, so unittests cannot be run."
 
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -15,59 +15,33 @@ AM_PROG_AR
 
 dnl ----- The gtest dependency
 
-AC_ARG_WITH([gtest], AS_HELP_STRING(
-    [--with-gtest], [use gtest, which is required for running the unit tests
-      with make check. The value download, which is the default, downloads
-      gtest if a gtest source directory cannot be found. Per the recommendation
-      of the gtest documentation, gtest is compiled with the tests, so an
-      installed gtest is not usable - you need the gtest source. GTEST_PATH
-      indicates where to look for gtest and it is also where gtest
-      will be downloaded to if not found. The default path is srcdir/libs/gtest/ so
-      that gtest needs to be at srcdir/libs/gtest/ where srcdir is the
-      base of the directory being configured from.]
-))
+AC_ARG_WITH([gtest],
+    [AS_HELP_STRING([--with-gtest],
+        [use gtest, which is required for running the unit tests
+         with make check [default=yes].])],,
+    [with_gtest=yes])
 
-AC_MSG_CHECKING([for gtest])
-AS_IF([test "x$GTEST_PATH" == "x"], [GTEST_PATH="$srcdir/libs/gtest"])
-AS_IF([test "x$GTEST_VERSION" == "x"], [GTEST_VERSION="1.6.0"])
-AS_IF([test "x$with_gtest" == "x"], [with_gtest="download"])
+AC_DEFUN([NO_GTEST_ERROR],
+    [AC_MSG_ERROR([gtest not found; try again using --without-gtest])])
 
-AS_IF([test "x$with_gtest" == "xdownload"],
-  [with_gtest="yes"; AS_IF([test -e "$GTEST_PATH/src/gtest-all.cc"], [], [
-    echo "downloading of gtest disabled" >&2; exit 1
-    mkdir -p "$GTEST_PATH";
-    (
-      cd $GTEST_PATH;
-      rm -rf gtest-$GTEST_VERSION.zip
-      wget http://googletest.googlecode.com/files/gtest-$GTEST_VERSION.zip;
-      unzip gtest-$GTEST_VERSION.zip;
-      rm gtest-$GTEST_VERSION.zip
-      rm -rf gtest/
-      mv gtest-$GTEST_VERSION/ gtest/
-    );
-    if test ! -e "$GTEST_PATH/src/gtest-all.cc"; then
-      AC_MSG_WARN([Failed to download or extract gtest.]);
-      with_gtest="no";
-    else
-      with_gtest="yes";
-    fi
-  ])],
-  [test "x$with_gtest" == "xyes"], [
-    AS_IF([test -e "$GTEST_PATH/src/gtest-all.cc"], [], [
-      AC_MSG_ERROR([could not find gtest source at path $GTEST_PATH.])
-    ])
-  ],
-  [test "x$with_gtest" == "xno"], [],
-  [AC_MSG_ERROR([invalid value $with_gtest for with_gtest.])]
-)
-AS_IF([test "x$with_gtest" == "xyes"],
-  [GTEST_CFLAGS="-I$GTEST_PATH/include -I$GTEST_PATH"]);
-AM_CONDITIONAL(with_gtest, test "x$with_gtest" == "xyes")
+AS_IF([test "x$with_gtest" != "xno"],
+     [AC_LANG([C++])
+      AC_CHECK_HEADER([gtest/gtest.h],
+         [AC_MSG_CHECKING([for library containing testing::InitGoogleTest])
+          SAVELIBS=$LIBS
+          LIBS="$LIBS -lgtest"
+          AC_LINK_IFELSE(
+              [AC_LANG_PROGRAM([
+                  #include <gtest/gtest.h>
+                  ], [
+                  testing::InitGoogleTest()])],
+              [AC_MSG_RESULT([-lgtest])],
+              [AC_MSG_RESULT([no])
+               NO_GTEST_ERROR])
+          LIBS=$SAVELIBS],
+         [NO_GTEST_ERROR])])
 
-DEPS_CFLAGS="$GTEST_CFLAGS"
-DEPS_LIBS="$GTEST_LIBS"
-AC_SUBST(DEPS_CFLAGS)
-AC_SUBST(DEPS_LIBS)
+AM_CONDITIONAL([with_gtest], [test "x$with_gtest" != "xno"])
 
 # Enable optional maintainer mode (off by default)
 dnl AM_MAINTAINER_MODE turns off automatic reconstruction of the build

--- a/src/test/gtestInclude.cpp
+++ b/src/test/gtestInclude.cpp
@@ -1,8 +1,0 @@
-// Includes a file from gtest that pulls in all of the implementation
-// of gtest. The gtest docs recommend building gtest individually for
-// each program rather than using an installed gtest and this is as
-// easy a way of doing it as any. Especially because it guarantees that
-// the compiler flags are the same, which is the whole point of the
-// recommendation to build gtest for each program.
-
-#include "src/gtest-all.cc"


### PR DESCRIPTION
The source isn't available in all platforms' googletest packages (e.g., Fedora), and the recommendation to compile unit tests using gtest-all.cc has been deprecated.

Also don't worry about downloading gtest if it's not found.