### PR TITLE
More googletest updates

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,7 @@ AS_IF([test "x$with_gtest" != "xno"],
       AC_CHECK_HEADER([gtest/gtest.h],
          [AC_MSG_CHECKING([for library containing testing::InitGoogleTest])
           SAVELIBS=$LIBS
-          LIBS="$LIBS -lgtest"
+          LIBS="$LIBS -lgtest -pthread"
           AC_LINK_IFELSE(
               [AC_LANG_PROGRAM([
                   #include <gtest/gtest.h>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,7 +46,7 @@ if(BUILD_TESTING)
     include(FetchContent)
     FetchContent_Declare(googletest
       GIT_REPOSITORY https://github.com/google/googletest.git
-      GIT_TAG        release-1.11.0
+      GIT_TAG        release-1.16.0
       )
     FetchContent_MakeAvailable(googletest)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,7 +46,7 @@ if(BUILD_TESTING)
     include(FetchContent)
     FetchContent_Declare(googletest
       GIT_REPOSITORY https://github.com/google/googletest.git
-      GIT_TAG        release-1.16.0
+      GIT_TAG        v1.16.0
       )
     FetchContent_MakeAvailable(googletest)
 


### PR DESCRIPTION
A couple small googletest updates to squeeze in before the Macaulay2 1.25.05 release:

* Fetch 1.16 to fix the build with the latest version of cmake
* Include the pthreads flag for proper detection on some systems (e.g., RHEL) in the autotools build

Cc: @mahrud