### PR TITLE
Various build updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,13 +12,10 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install -y libgtest-dev
-      - name: Build memtailor
+      - name: Build and check memtailor
         run: |
-          ./autogen.sh
-          cd build/autotools
-          ../../configure
-          make
-      - name: Check memtailor
-        run: |
-          cd build/autotools
+          mkdir BUILD
+          cd BUILD
+          ../autogen.sh
+          ../configure
           make distcheck

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,20 +2,37 @@ name: Build
 on:
   workflow_dispatch:
   pull_request:
-  push:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        build-system:
+          - autotools
+          - cmake
+        os:
+          - macos-latest
+          - ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Install dependencies
         run: |
-          sudo apt-get install -y libgtest-dev
+          if test ${{ matrix.os }} = ubuntu-latest
+          then sudo apt-get install -y libgtest-dev
+          else brew install autoconf automake libtool googletest
+               echo "CPPFLAGS=-I$(brew --prefix)/include" >> $GITHUB_ENV
+               echo "LDFLAGS= -L$(brew --prefix)/lib"     >> $GITHUB_ENV
+          fi
       - name: Build and check memtailor
         run: |
-          mkdir BUILD
-          cd BUILD
-          ../autogen.sh
-          ../configure
-          make distcheck
+          mkdir build-dir
+          cd build-dir
+          if test ${{ matrix.build-system }} = autotools
+          then ../autogen.sh
+               ../configure
+               make distcheck
+          else cmake -B. -S.. -GNinja
+               ninja
+          fi

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,7 @@ AM_CPPFLAGS = -I${top_srcdir}/
 lib_LTLIBRARIES = libmemtailor.la
 
 # set the C++ compiler to include src/
-AM_CXXFLAGS=-I$(top_srcdir)/src/ -std=gnu++17
+AM_CXXFLAGS=-I$(top_srcdir)/src/
 
 # the sources that are built to make the library
 libmemtailor_la_SOURCES =		\
@@ -40,7 +40,7 @@ if with_gtest
 TESTS=unittest
 check_PROGRAMS=$(TESTS)
 
-unittest_CXXFLAGS = -I$(top_srcdir)/src/ -std=gnu++17
+unittest_CXXFLAGS = -I$(top_srcdir)/src/
 unittest_LDADD = $(top_builddir)/libmemtailor.la -lpthread -lgtest
 
 # test_LIBS=

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,9 +8,6 @@ AM_CPPFLAGS = -I${top_srcdir}/
 # tell Libtool what the name of the library is.
 lib_LTLIBRARIES = libmemtailor.la
 
-# set the C++ compiler to include src/
-AM_CXXFLAGS=-I$(top_srcdir)/src/
-
 # the sources that are built to make the library
 libmemtailor_la_SOURCES =		\
   src/memtailor/BufferPool.cpp src/memtailor/Arena.cpp	\
@@ -40,7 +37,6 @@ if with_gtest
 TESTS=unittest
 check_PROGRAMS=$(TESTS)
 
-unittest_CXXFLAGS = -I$(top_srcdir)/src/
 unittest_LDADD = $(top_builddir)/libmemtailor.la -lpthread -lgtest
 
 # test_LIBS=

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
-srcdir="`dirname '$0'`"
+srcdir=$(dirname $0)
+test -z "$srcdir" && srcdir=.
 
 autoreconf --verbose --install --force $srcdir

--- a/configure.ac
+++ b/configure.ac
@@ -95,6 +95,9 @@ AS_IF([test "x$with_gtest" != "xno"],
 
 AM_CONDITIONAL([with_gtest], [test "x$with_gtest" != "xno"])
 
+CPPFLAGS="$CPPFLAGS -I$srcdir/src"
+AC_SUBST([CPPFLAGS])
+
 dnl Set up AC_OUTPUT to create each file by copying an input file
 dnl while substituting the output variable values.
 AC_CONFIG_FILES([Makefile

--- a/src/memtailor.cpp
+++ b/src/memtailor.cpp
@@ -5,5 +5,5 @@
 
 extern "C" {
   void libmemtailorIsPresent(void) {}
-  char MEMTAILOR_VERSION_STRING[] = PACKAGE_VERSION;
+  char MEMTAILOR_VERSION_STRING[] = "1.1";
 }


### PR DESCRIPTION
* Remove some unnecessary build flags:
   - C++17 is now handled in the configure script, so we don't need to do it in the Makefile
   - automake already takes care of adding the `-I` flags for the source directory, so we don't need to worry about adding it.  Plus `CXXFLAGS` is the wrong variable for that anyway.
   - Set the `I$(srcdir)/src` build flags in `configure`
 * Allow running `autogen.sh` from the build directory
 * Update the GitHub workflow -- cmake & macOS builds now supported
 * Go back to hard-coding the version number since the M2 cmake build only uses the `src` directory.