### PR TITLE
Clear the record of allocations in Arena::freeAllAllocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,24 @@ standard, it will not cause a stack overflow, you can have multiple
 arena allocators at the same time and allocation is not tied to a
 function invocation.
 
+Debugging
+---------
+
+Defining MEMT_DEBUG turns on memtailor's internal consistency checks. Pass
+--enable-debug to configure, or build with cmake and -DCMAKE_BUILD_TYPE=Debug.
+
+Be aware that MEMT_DEBUG adds a member to memt::Arena, so it changes the size
+of that class and hence the ABI of the library. It must match between the
+library and every translation unit that includes these headers. Mixing the
+two compiles and links without complaint, but the two sides then disagree
+about the layout of memt::Arena and the result is undefined behavior.
+
+The autotools build records the setting in the Cflags of memtailor.pc. That
+only helps if you use those Cflags in full, as pkg-config --cflags-only-I
+drops it, and so does any build system that keeps just the include
+directories. The cmake build installs no memtailor.pc at all. So it is
+ultimately up to you to keep the library and its users consistent.
+
 The following copyright and license notice applies to all of the files in
 memtailor.
 

--- a/build/autotools/memtailor.pc.in
+++ b/build/autotools/memtailor.pc.in
@@ -9,4 +9,4 @@ URL: https://github.com/broune/memtailor
 Requires:
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -lmemtailor
-Cflags: -I${includedir}
+Cflags: -I${includedir} @MEMT_DEBUG_CFLAGS@

--- a/configure.ac
+++ b/configure.ac
@@ -95,6 +95,24 @@ AS_IF([test "x$with_gtest" != "xno"],
 
 AM_CONDITIONAL([with_gtest], [test "x$with_gtest" != "xno"])
 
+dnl ----- The MEMT_DEBUG option
+
+AC_ARG_ENABLE([debug],
+    [AS_HELP_STRING([--enable-debug],
+        [turn on memtailor's internal consistency checks (MEMT_DEBUG).
+         This changes the ABI of the library, so it must match in every
+         translation unit that includes memtailor's headers
+         [default=no].])],,
+    [enable_debug=no])
+
+dnl Put MEMT_DEBUG in the Cflags of memtailor.pc as well, so that users
+dnl of pkg-config match the library automatically.
+AS_IF([test "x$enable_debug" != "xno"],
+    [MEMT_DEBUG_CFLAGS=-DMEMT_DEBUG
+     CPPFLAGS="$CPPFLAGS $MEMT_DEBUG_CFLAGS"],
+    [MEMT_DEBUG_CFLAGS=])
+AC_SUBST([MEMT_DEBUG_CFLAGS])
+
 CPPFLAGS="$CPPFLAGS -I$srcdir/src"
 AC_SUBST([CPPFLAGS])
 

--- a/src/memtailor/Arena.cpp
+++ b/src/memtailor/Arena.cpp
@@ -18,6 +18,9 @@ namespace memt {
     while (block().hasPreviousBlock())
       _blocks.freePreviousBlock();
     block().clear();
+#ifdef MEMT_DEBUG
+    _debugAllocs.clear();
+#endif
   }
 
   void Arena::freeAllAllocsAndBackingMemory() {

--- a/src/memtailor/Arena.h
+++ b/src/memtailor/Arena.h
@@ -208,6 +208,13 @@ namespace memt {
     /** Returns true if there are no live allocations for this Arena. */
     inline bool isEmpty() const;
 
+#ifdef MEMT_DEBUG
+    /** Returns the number of live allocations according to the DEBUG-only
+        record of allocations. This is zero if and only if isEmpty() is
+        true. This method is useful for debugging and testing. */
+    size_t debugAllocCount() const {return _debugAllocs.size();}
+#endif
+
     /** Returns the total amount of memory allocated by this object. Includes
         excess capacity that has not been allocated by a client yet. Does NOT
         include memory for a DEBUG-only mechanism to catch bugs. */

--- a/src/test/ArenaTest.cpp
+++ b/src/test/ArenaTest.cpp
@@ -273,3 +273,36 @@ TEST(Arena, Guard) {
   ASSERT_TRUE(arena.fromArena(fromIteration3));
   arena.freeAndAllAfter(fromIteration3);
 }
+
+TEST(Arena, FreeAllAllocs) {
+  memt::Arena arena;
+  arena.alloc(1);
+  // allocate enough memory to force a new block of backing memory inside
+  // the arena, so that freeAllAllocs has a previous block to free.
+  arena.alloc(arena.getMemoryUse() + 1);
+  ASSERT_FALSE(arena.isEmpty());
+#ifdef MEMT_DEBUG
+  ASSERT_EQ(arena.debugAllocCount(), 2u);
+#endif
+
+  arena.freeAllAllocs();
+  ASSERT_TRUE(arena.isEmpty());
+#ifdef MEMT_DEBUG
+  ASSERT_EQ(arena.debugAllocCount(), 0u);
+#endif
+  memt::Arena::Guard guard(arena); // must be possible on an empty arena
+}
+
+TEST(Arena, GuardAfterEmptyRestore) {
+  memt::Arena arena;
+  {
+    // guard point for an empty arena; restoring to it uses freeAllAllocs
+    memt::Arena::Guard guard(arena);
+    arena.alloc(1);
+  }
+  ASSERT_TRUE(arena.isEmpty());
+#ifdef MEMT_DEBUG
+  ASSERT_EQ(arena.debugAllocCount(), 0u);
+#endif
+  memt::Arena::Guard guard2(arena); // must be possible on an empty arena
+}


### PR DESCRIPTION
`Arena` keeps a record of live allocations when `MEMT_DEBUG` is defined. Every
way of freeing memory maintains that record except `freeAllAllocs`, which
empties the arena but leaves the record populated.

`restoreToGuardPoint` reaches `freeAllAllocs` on the empty-arena path
(`Arena.h:423-426`), so this aborts:

```cpp
memt::Arena arena;
{
  memt::Arena::Guard guard(arena);  // guard point is 0: the arena is empty
  arena.alloc(1);
}                                   // ~guard -> freeAllAllocs()
memt::Arena::Guard guard2(arena);   // Assertion `_debugAllocs.empty()' failed
```

`freeAllAllocs` had no direct test coverage at all. `TEST(Arena, Guard)` does
reach the inconsistent state, but then refills the block, so every later
`guardPoint()` takes the `!block().empty()` branch, which only asserts the
record is *non*-empty. It passes without noticing.

### Commits

1. **Clear the record of allocations in `Arena::freeAllAllocs`** — the fix,
   plus a `MEMT_DEBUG`-only `debugAllocCount()` so the tests can state the
   invariant directly instead of relying on an `assert` aborting the whole
   test binary, plus tests for `freeAllAllocs` and for the guard sequence.
2. **`configure: add --enable-debug`** — `MEMT_DEBUG` was previously
   unreachable from the autotools build, so these checks were never exercised
   there. Also recorded in `memtailor.pc`'s Cflags.
3. **`README: document that MEMT_DEBUG changes the ABI`**.

### Verification

Both new tests fail before the fix and pass after. 24/24 under
`cmake -DCMAKE_BUILD_TYPE=Debug`, cmake default, autotools `--enable-debug`,
and autotools default; `make distcheck` passes both ways. `nm -D` on the
built library is byte-identical before and after, so there is no ABI change
and `debian/libmemtailor0.symbols` needs no update.

### Two notes

**This does not fix debug builds of MathicGB.** `freeAllAllocs` is out of line
in `Arena.cpp`, compiled into the shared library with `MEMT_DEBUG` undefined,
so the added `#ifdef` block is preprocessed away in the binary MathicGB links
against. MathicGB defines `-DMEMT_DEBUG` for its own translation units while
linking a library built without it; since `MEMT_DEBUG` adds a member to
`memt::Arena`, the two sides disagree about its size (56 vs 32 bytes on
x86-64 — the installed `_scratchArena` measures 0x20). That is a separate
problem and has to be fixed in MathicGB.

**Unrelated bug found while reviewing this, not addressed here.**
`restoreToGuardPoint` resets the position of every block newer than the guard
point but never frees them, breaking the invariant that an empty block has
been deallocated — stated at `Arena.h:403-406` and relied on by
`freeTopFromOldBlock`. With two or more blocks created inside a guard, a
subsequent legal `freeTop` asserts in a debug build and silently corrupts the
block chain in a release build. Unlike the bug above, that one affects
ordinary release builds. I will open a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
