### PR TITLE
Maintain the invariant that no empty block sits behind the front block

### DIFF
--- a/src/memtailor/Arena.cpp
+++ b/src/memtailor/Arena.cpp
@@ -52,6 +52,11 @@ namespace memt {
     MEMT_ASSERT(size >= needed);
     MEMT_ASSERT(size % MemoryAlignment == 0);
     _blocks.allocBlock(size);
+
+    // guardPoint() and freeTopFromOldBlock() both require that a block
+    // behind the front block is not empty.
+    if (block().hasPreviousBlock() && block().previousBlock()->empty())
+      _blocks.freePreviousBlock();
   }
 
   void Arena::freeTopFromOldBlock(void* ptr) {

--- a/src/memtailor/Arena.h
+++ b/src/memtailor/Arena.h
@@ -433,15 +433,28 @@ namespace memt {
 	  return;
 	}
 
+	// The blocks allocated since the guard point have to be deallocated,
+	// as guardPoint() and freeTopFromOldBlock() both rely on a block
+	// behind the front block never being empty.
 	Block* b = &block();
-	while (!(b->begin() < ptr && ptr <= b->end())) {
+	if (!(b->begin() < ptr && ptr <= b->end())) {
 	  b->setPosition(b->begin());
-	  b = b->previousBlock();
+	  do {
+		// If you get an assert here then most likely the guard point was
+		// invalidated by deallocating memory that was live at the point
+		// the guard point was created.
+		MEMT_ASSERT(b->hasPreviousBlock());
+		b = b->previousBlock();
+	  } while (!(b->begin() < ptr && ptr <= b->end()));
 
-	  // If you get an assert here then most likely the guard point was
-	  // invalidated by deallocating memory that was live at the point
-	  // the guard point was created.
-	  MEMT_ASSERT(b != 0);
+#ifdef MEMT_DEBUG
+	  // Drop the record of the allocations in the blocks that are about to
+	  // be freed while their addresses are still valid.
+	  while (!_debugAllocs.empty() && !b->isInBlock(_debugAllocs.back()))
+		_debugAllocs.pop_back();
+#endif
+	  while (block().previousBlock() != b)
+		_blocks.freePreviousBlock();
 	}
  	MEMT_ASSERT(b->begin() < ptr && ptr <= b->end());
 	b->setPosition(ptr);

--- a/src/test/ArenaTest.cpp
+++ b/src/test/ArenaTest.cpp
@@ -306,3 +306,32 @@ TEST(Arena, GuardAfterEmptyRestore) {
 #endif
   memt::Arena::Guard guard2(arena); // must be possible on an empty arena
 }
+
+TEST(Arena, GuardFreesNewerBlocks) {
+  memt::Arena arena;
+  void* a = arena.alloc(1);
+  size_t memoryUse = 0;
+  {
+    memt::Arena::Guard guard(arena);
+    // Two new blocks, not one: with one, the only block left empty is
+    // the front block, which is allowed. With two there is also an empty
+    // block behind it, which is not.
+    arena.alloc(arena.getMemoryUse() + 1);
+    arena.alloc(arena.getMemoryUse() + 1);
+    memoryUse = arena.getMemoryUse();
+  }
+  // the block in the middle is deallocated. As for freeAndAllAfter, the
+  // front block is kept, so not all of the memory is released.
+  ASSERT_LT(arena.getMemoryUse(), memoryUse);
+
+  {
+    memt::Arena::Guard guard(arena); // requires no empty block behind the front
+  }
+
+  arena.freeTop(a); // a is the only allocation that is still live
+  ASSERT_TRUE(arena.isEmpty());
+  ASSERT_EQ(arena.getAllocatedMemoryUse(), 0u);
+#ifdef MEMT_DEBUG
+  ASSERT_EQ(arena.debugAllocCount(), 0u);
+#endif
+}

--- a/src/test/ArenaTest.cpp
+++ b/src/test/ArenaTest.cpp
@@ -335,3 +335,19 @@ TEST(Arena, GuardFreesNewerBlocks) {
   ASSERT_EQ(arena.debugAllocCount(), 0u);
 #endif
 }
+
+TEST(Arena, EmptyBlockIsNotKeptBehindFrontBlock) {
+  memt::Arena arena;
+  void* p = arena.alloc(1);
+  void* q = arena.alloc(arena.getMemoryUse() + 1);
+  arena.freeTop(q);
+  void* r = arena.alloc(arena.getMemoryUse() + 1);
+  arena.freeTop(r);
+
+  arena.freeTop(p); // p is in the first block
+  ASSERT_TRUE(arena.isEmpty());
+  ASSERT_EQ(arena.getAllocatedMemoryUse(), 0u);
+#ifdef MEMT_DEBUG
+  ASSERT_EQ(arena.debugAllocCount(), 0u);
+#endif
+}


### PR DESCRIPTION
`guardPoint()` documents an invariant:

```cpp
if (block().hasPreviousBlock()) {
  // The previous block is not empty as then it would have been
  // deallocated, so it is safe to take the guard point from the
  // previous block.
  MEMT_ASSERT(!block().previousBlock()->empty());
```

`freeTopFromOldBlock()` relies on it too. Nothing maintained it. There are two
independent ways to end up with an empty block behind the front block, and
this fixes both — one commit each, with a regression test each.

### 1. `restoreToGuardPoint` emptied blocks without deallocating them

It reset the position of every block newer than the guard point but never
freed them. Two blocks inside a guard are needed to show it, since with one
the only empty block is the front block, which is allowed:

```cpp
memt::Arena arena;
void* a = arena.alloc(1);
{
  memt::Arena::Guard guard(arena);
  arena.alloc(arena.getMemoryUse() + 1);
  arena.alloc(arena.getMemoryUse() + 1);
}
arena.freeTop(a); // a is the only allocation that is still live
```

The commit also drops the `_debugAllocs` entries for the blocks being freed
*before* freeing them, so no freed address is used afterwards.

### 2. `growCapacity` chained an empty front block behind the new one

`alloc()` grows the capacity whenever a request does not fit in what is left
of the front block — including when that block is empty. **No guard point is
involved**, so this is reachable from plain `alloc`/`freeTop`:

```cpp
memt::Arena a;
void* p = a.alloc(1);                     // block A
void* q = a.alloc(a.getMemoryUse() + 1);  // block B, A behind it
a.freeTop(q);                             // B is empty now
void* r = a.alloc(a.getMemoryUse() + 1);  // block C, B empty behind it
a.freeTop(r);
a.freeTop(p);                             // p is in A, but B is examined
```

Fixed in `growCapacity` rather than in `MemoryBlocks`, as `BufferPool` shares
the latter and has no such requirement.

### Symptoms

Both cases behave identically. With `MEMT_DEBUG`, `Arena.cpp` aborts on
`Assertion 'previous->isInBlock(ptr)' failed` in `freeTopFromOldBlock`.
Without it, the position of one block is set to an address inside another and
`getAllocatedMemoryUse()` wraps around to a huge value. Using a `Guard`
instead of the final `freeTop` trips `!block().previousBlock()->empty()` in
`guardPoint()` instead.

Case 2 is the more serious of the two: it needs no guard points, and it
corrupts the block chain silently in ordinary release builds.

### Verification

26/26 under `cmake -DCMAKE_BUILD_TYPE=Debug`, cmake default, and autotools.
`make distcheck` passes with and without `--enable-debug`. Clean under
AddressSanitizer and UndefinedBehaviorSanitizer.

Each regression test fails before its fix and passes after, in **both** debug
and release builds, so neither depends on `MEMT_DEBUG` being defined.

A fuzzer doing random valid operations (nested guards, released guards, LIFO
`freeTop`, `freeAndAllAfter`, block-forcing allocations) runs clean over 10
seeds x 400 trials in both builds, and reproduces the bug on 5 of 5 seeds
against `master`.

The two commits are independent and either can be dropped without affecting
the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
