### PR TITLE
Use an inline constexpr for implicit inlining

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ standard, it will not cause a stack overflow, you can have multiple
 arena allocators at the same time and allocation is not tied to a
 function invocation.
 
+Requirements
+------------
+
+Memtailor requires C++17 or later.
+
 Debugging
 ---------
 

--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,8 @@ AC_PROG_INSTALL
 # Locate the C++ compiler.
 AC_PROG_CXX
 
+AX_CXX_COMPILE_STDCXX([17], [], [mandatory])
+
 # Set up LibTool
 LT_INIT([disable-shared])
 
@@ -77,7 +79,6 @@ AC_DEFUN([NO_GTEST_ERROR],
 
 AS_IF([test "x$with_gtest" != "xno"],
      [AC_LANG([C++])
-      AX_CXX_COMPILE_STDCXX([17], [], [mandatory])
       AC_CHECK_HEADER([gtest/gtest.h],
          [AC_MSG_CHECKING([for library containing testing::InitGoogleTest])
           SAVELIBS=$LIBS

--- a/src/memtailor/stdinc.h
+++ b/src/memtailor/stdinc.h
@@ -98,9 +98,10 @@ namespace memt {
   /// The alignment that memory allocators must ensure. In other words
   /// allocators must return pointer addresses that are divisible by
   /// MemoryAlignment. MemoryAlignment must be a power of 2.
-  static const unsigned int MemoryAlignment = static_cast<unsigned int>(sizeof(void*));
+  inline constexpr unsigned int MemoryAlignment =
+    static_cast<unsigned int>(sizeof(void*));
 
-  static const unsigned int BitsPerByte = 8;
+  inline constexpr unsigned int BitsPerByte = 8;
 }
 
 #endif

--- a/src/memtailor/stdinc.h
+++ b/src/memtailor/stdinc.h
@@ -4,6 +4,10 @@
 #ifndef MEMT_STDINC_GUARD
 #define MEMT_STDINC_GUARD
 
+#if __cplusplus < 201703L
+#error "memtailor requires C++17 or later"
+#endif
+
 #ifdef _MSC_VER // For Microsoft Compiler in Visual Studio C++.
 // Sometimes you know that a function will be called very rarely so you want to
 // tell the compiler not to inline it even if it could be inlined at only a


### PR DESCRIPTION
A follow-up to Macaulay2/mathic#25 and Macaulay2/mathicgb#62, though the
conclusion here is different.

memtailor is **not** vulnerable to the undefined-reference bug from those PRs
(Debian #1145665). That one needs a class-scope `static const` with an in-class
initializer, which is only a declaration and needs an out-of-line definition
once odr-used. memtailor has none. Its only two constants are at *namespace*
scope, where `static const` is a definition in every translation unit, so no
linker error is possible. Nothing here is broken today.

What the sweep did turn up:

**Namespace-scope `static` means internal linkage**, so every TU including
`memtailor.h` got its own private copy of `MemoryAlignment` and `BitsPerByte`.
The inline functions in `MemoryBlocks.h` name both, which is well defined only
thanks to the carve-out in [basic.def.odr] for const objects of literal type
holding the same value in every definition. `inline constexpr` makes each a
single entity and drops the reliance on that carve-out. Note that plain
`constexpr` would not have been enough: at namespace scope it implies `const`
and hence internal linkage, so `inline` is the part doing the work.

**`AX_CXX_COMPILE_STDCXX` sat inside the `AS_IF` guarding the gtest checks**, so
`--without-gtest` asked for no particular standard at all. The headers need
C++17 whether or not we build the unit tests. `AC_LANG` stays behind in the
gtest block, since `AX_CXX_COMPILE_STDCXX` does its own `AC_LANG_PUSH([C++])`
but `AC_CHECK_HEADER([gtest/gtest.h])` does need the C++ compiler selected.

The `#error` guard then gives downstream users a clear diagnostic, which matters
now that the headers contain an inline variable.

Tested: `make distcheck`, and `make check` under both `--with-gtest` and
`--without-gtest` from a clean out-of-tree build; cmake builds with 26/26 tests
passing. Confirmed the guard fires at `-std=c++14`, and that under a forced
odr-use at `-O0` `nm` now reports a single unique global symbol for each
constant rather than a per-TU local.

One caveat worth flagging: the toolchain I tested on has gtest 1.14, so these
runs are not evidence about gtest 1.18 specifically. The absence of class-scope
statics is the reason to expect memtailor is clear there, not the test runs.

Claude Opus 5 did the analysis and drafted the changes.